### PR TITLE
Add Vitest setup and business logic unit tests

### DIFF
--- a/Uriel Paul/book-review-app/package.json
+++ b/Uriel Paul/book-review-app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "15.4.6",
@@ -18,8 +19,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "autoprefixer": "^10.4.21",
+    "jsdom": "^24.0.0",
     "postcss": "^8.5.6",
+    "vitest": "^2.0.5",
     "tailwindcss": "^3.4.10",
     "typescript": "^5"
   }

--- a/Uriel Paul/book-review-app/src/components/StarRating.test.tsx
+++ b/Uriel Paul/book-review-app/src/components/StarRating.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { StarRating } from './StarRating'
+
+describe('StarRating', () => {
+  it('renders five stars with initial value', () => {
+    render(<StarRating value={2} />)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(5)
+    expect(radios[1]).toHaveAttribute('aria-checked', 'true')
+    expect(radios[2]).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('calls onChange when a star is clicked', async () => {
+    const user = userEvent.setup()
+    const fn = vi.fn()
+    render(<StarRating onChange={fn} />)
+    await user.click(screen.getAllByRole('radio')[3])
+    expect(fn).toHaveBeenCalledWith(4)
+  })
+
+  it('shows hover state', () => {
+    render(<StarRating value={1} />)
+    const star = screen.getAllByRole('radio')[4]
+    fireEvent.mouseEnter(star)
+    expect(star).toHaveTextContent('★')
+    fireEvent.mouseLeave(star)
+    expect(star).toHaveTextContent('☆')
+  })
+})
+

--- a/Uriel Paul/book-review-app/src/lib/googleBooks.test.ts
+++ b/Uriel Paul/book-review-app/src/lib/googleBooks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { searchBooks, getBookById } from './googleBooks'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch as any
+
+describe('googleBooks api', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('searchBooks maps results', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          { id: '1', volumeInfo: { title: 't', authors: ['a'], categories: ['c'], imageLinks: { thumbnail: 'img' }, pageCount: 10 } },
+        ],
+      }),
+    })
+    const res = await searchBooks('harry')
+    expect(mockFetch).toHaveBeenCalled()
+    expect(res[0]).toMatchObject({ id: '1', title: 't', authors: ['a'], categories: ['c'] })
+  })
+
+  it('searchBooks throws on error status', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+    await expect(searchBooks('x')).rejects.toThrow('Google Books error: 500')
+  })
+
+  it('getBookById returns null on non-ok', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false })
+    expect(await getBookById('1')).toBeNull()
+  })
+
+  it('getBookById maps volume info', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'a', volumeInfo: { title: 'T', authors: ['A'] } }),
+    })
+    const book = await getBookById('a')
+    expect(book).toMatchObject({ id: 'a', title: 'T', authors: ['A'], categories: [] })
+  })
+})
+

--- a/Uriel Paul/book-review-app/src/lib/ranking.test.ts
+++ b/Uriel Paul/book-review-app/src/lib/ranking.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { wilsonScore } from './ranking'
+
+describe('wilsonScore', () => {
+  it('returns 0 when there are no votes', () => {
+    expect(wilsonScore(0, 0)).toBe(0)
+  })
+
+  it('increases with more positive votes', () => {
+    expect(wilsonScore(10, 0)).toBeGreaterThan(wilsonScore(1, 0))
+  })
+
+  it('is lower when negative votes increase', () => {
+    expect(wilsonScore(10, 5)).toBeLessThan(wilsonScore(10, 0))
+  })
+
+  it('matches known value', () => {
+    expect(wilsonScore(100, 0)).toBeCloseTo(0.963005, 6)
+  })
+})
+

--- a/Uriel Paul/book-review-app/src/lib/reviewsStore.test.ts
+++ b/Uriel Paul/book-review-app/src/lib/reviewsStore.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('reviewsStore', () => {
+  let addReview: any
+  let listReviews: any
+  let voteReview: any
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const mod = await import('./reviewsStore')
+    addReview = mod.addReview
+    listReviews = mod.listReviews
+    voteReview = mod.voteReview
+  })
+
+  it('adds and lists reviews', () => {
+    const r1 = addReview('b1', 'u1', 'Alice', 4, 'good')
+    const r2 = addReview('b1', 'u2', 'Bob', 5, 'great')
+    const list = listReviews('b1', 'rating')
+    expect(list).toHaveLength(2)
+    expect(list[0].id).toBe(r2.id) // highest rating first
+    expect(list[1].id).toBe(r1.id)
+  })
+
+  it('returns null when voting unknown review', () => {
+    expect(voteReview('nope', 'u1', 1)).toBeNull()
+  })
+
+  it('updates votes and toggles', () => {
+    const r = addReview('b1', 'u1', 'Alice', 3, 'ok')
+    const v1 = voteReview(r.id, 'voter', 1)!
+    expect(v1.upVotes).toBe(1)
+    const v2 = voteReview(r.id, 'voter', 1)!
+    expect(v2.upVotes).toBe(0) // removed
+  })
+
+  it('uses wilson score to update review score', async () => {
+    vi.resetModules()
+    const scoreMock = vi.fn(() => 0.42)
+    vi.mock('./ranking', () => ({ wilsonScore: scoreMock }))
+    const mod = await import('./reviewsStore')
+    const add = mod.addReview
+    const vote = mod.voteReview
+    const r = add('b1', 'u1', 'Alice', 3, 'ok')
+    const updated = vote(r.id, 'me', 1)!
+    expect(scoreMock).toHaveBeenCalledWith(1, 0)
+    expect(updated.score).toBe(0.42)
+  })
+})
+

--- a/Uriel Paul/book-review-app/vitest.config.ts
+++ b/Uriel Paul/book-review-app/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
+})
+

--- a/Uriel Paul/book-review-app/vitest.setup.ts
+++ b/Uriel Paul/book-review-app/vitest.setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom'
+


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom and setup for Testing Library
- add unit tests for ranking, reviews store and Google Books helpers
- cover StarRating component interaction with React Testing Library

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d9a7344832bb5f5d12ee77357d0