### PR TITLE
feat: add dark theme styling

### DIFF
--- a/Uriel Paul/Tarea10NoSQL/src/app/auth/login/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/auth/login/page.tsx
@@ -38,7 +38,7 @@ export default function LoginPage() {
           onChange={e => setEmail(e.target.value)}
           placeholder="Email"
           required
-          className="w-full border px-3 py-2 rounded"
+          className="w-full border border-gray-700 bg-gray-800 text-gray-100 px-3 py-2 rounded"
         />
         <input
           type="password"
@@ -46,9 +46,9 @@ export default function LoginPage() {
           onChange={e => setPassword(e.target.value)}
           placeholder="Contraseña"
           required
-          className="w-full border px-3 py-2 rounded"
+          className="w-full border border-gray-700 bg-gray-800 text-gray-100 px-3 py-2 rounded"
         />
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-400">{error}</p>}
         <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Entrar</button>
       </form>
     </main>

--- a/Uriel Paul/Tarea10NoSQL/src/app/auth/register/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/auth/register/page.tsx
@@ -38,7 +38,7 @@ export default function RegisterPage() {
           onChange={e => setName(e.target.value)}
           placeholder="Nombre"
           required
-          className="w-full border px-3 py-2 rounded"
+          className="w-full border border-gray-700 bg-gray-800 text-gray-100 px-3 py-2 rounded"
         />
         <input
           type="email"
@@ -46,7 +46,7 @@ export default function RegisterPage() {
           onChange={e => setEmail(e.target.value)}
           placeholder="Email"
           required
-          className="w-full border px-3 py-2 rounded"
+          className="w-full border border-gray-700 bg-gray-800 text-gray-100 px-3 py-2 rounded"
         />
         <input
           type="password"
@@ -54,9 +54,9 @@ export default function RegisterPage() {
           onChange={e => setPassword(e.target.value)}
           placeholder="Contraseña"
           required
-          className="w-full border px-3 py-2 rounded"
+          className="w-full border border-gray-700 bg-gray-800 text-gray-100 px-3 py-2 rounded"
         />
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-400">{error}</p>}
         <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Registrarse</button>
       </form>
     </main>

--- a/Uriel Paul/Tarea10NoSQL/src/app/book/[id]/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/book/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function BookPage({ params }: PageCtx) {
     <main className="mx-auto max-w-3xl p-6 space-y-6">
       <header className="space-y-2">
         <h1 className="text-2xl font-bold">{book.title}</h1>
-        <ul className="text-sm text-gray-700 space-y-1">
+        <ul className="text-sm text-gray-300 space-y-1">
           {meta.filter(([, v]) => v).map(([k, v]) => (
             <li key={k}><span className="font-medium">{k}:</span> {v as any}</li>
           ))}
@@ -51,7 +51,7 @@ export default async function BookPage({ params }: PageCtx) {
       </header>
 
       {book.description && (
-        <article className="prose max-w-none">
+        <article className="prose prose-invert max-w-none">
           <h2>Descripción</h2>
           <div dangerouslySetInnerHTML={{ __html: book.description }} />
         </article>

--- a/Uriel Paul/Tarea10NoSQL/src/app/favorites/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/favorites/page.tsx
@@ -63,7 +63,7 @@ export default function FavoritesPage() {
                   className="w-12 h-auto rounded shadow"
                 />
               )}
-              <Link href={`/book/${b.id}`} className="text-blue-600">
+              <Link href={`/book/${b.id}`} className="text-blue-400">
                 {b.title}
               </Link>
             </li>

--- a/Uriel Paul/Tarea10NoSQL/src/app/globals.css
+++ b/Uriel Paul/Tarea10NoSQL/src/app/globals.css
@@ -9,3 +9,9 @@ html, body, #__next {
 body {
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji";
 }
+
+input,
+textarea,
+select {
+  @apply bg-gray-800 text-gray-100 border border-gray-700 rounded;
+}

--- a/Uriel Paul/Tarea10NoSQL/src/app/layout.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es">
-      <body className="bg-gray-50 text-gray-900">
+      <body className="bg-gray-900 text-gray-100">
         <NavBar />
         {children}
       </body>

--- a/Uriel Paul/Tarea10NoSQL/src/app/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
           value={q}
           onChange={e=>setQ(e.target.value)}
           placeholder="Título, autor o ISBN (p.ej. inauthor:rowling)"
-          className="flex-1 border rounded px-3 py-2"
+          className="flex-1 border border-gray-700 bg-gray-800 rounded px-3 py-2 text-gray-100"
         />
         <button className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50" disabled={!q}>Buscar</button>
       </form>
@@ -40,12 +40,12 @@ export default function Home() {
 
       <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {items.map(b => (
-          <li key={b.id} className="border rounded-xl p-3 flex gap-3">
+          <li key={b.id} className="border border-gray-700 rounded-xl p-3 flex gap-3 bg-gray-800">
             {b.thumbnail && <img src={b.thumbnail} alt="cover" className="w-16 h-24 object-cover rounded" />}
             <div>
               <div className="font-semibold">{b.title}</div>
-              <div className="text-sm text-gray-600">{b.authors?.join(', ')}</div>
-              <Link href={`/book/${b.id}`} className="text-blue-600 text-sm">Ver detalles →</Link>
+              <div className="text-sm text-gray-400">{b.authors?.join(', ')}</div>
+              <Link href={`/book/${b.id}`} className="text-blue-400 text-sm">Ver detalles →</Link>
             </div>
           </li>
         ))}

--- a/Uriel Paul/Tarea10NoSQL/src/app/reviews/page.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/app/reviews/page.tsx
@@ -86,7 +86,7 @@ export default function MyReviewsPage() {
       <h1 className="text-2xl font-bold">Mis reseñas</h1>
       {reviews.length === 0 && <p>No tenés reseñas.</p>}
       {reviews.map(r => (
-        <div key={r.id} className="border rounded-xl p-4 space-y-2">
+        <div key={r.id} className="border border-gray-700 rounded-xl p-4 space-y-2 bg-gray-800">
           <Link href={`/book/${r.bookId}`} className="flex items-center gap-2">
             {r.book?.thumbnail && (
               <img
@@ -95,19 +95,19 @@ export default function MyReviewsPage() {
                 className="w-12 h-16 object-cover"
               />
             )}
-            <span className="font-semibold">{r.book?.title ?? 'Ver libro'}</span>
+            <span className="font-semibold text-blue-400">{r.book?.title ?? 'Ver libro'}</span>
           </Link>
           {editingId === r.id ? (
             <>
               <StarRating value={editRating} onChange={setEditRating} />
               <textarea
-                className="w-full border rounded p-2"
+                className="w-full border border-gray-700 rounded p-2 bg-gray-800 text-gray-100"
                 value={editContent}
                 onChange={e => setEditContent(e.target.value)}
               />
               <div className="flex gap-2 text-sm">
                 <button onClick={saveEdit} className="px-2 py-1 bg-blue-600 text-white rounded">Guardar</button>
-                <button onClick={() => setEditingId(null)} className="px-2 py-1 border rounded">Cancelar</button>
+                <button onClick={() => setEditingId(null)} className="px-2 py-1 border border-gray-700 rounded">Cancelar</button>
               </div>
             </>
           ) : (
@@ -115,8 +115,8 @@ export default function MyReviewsPage() {
               <div className="text-yellow-500">{'★'.repeat(r.rating)}{'☆'.repeat(5-r.rating)}</div>
               <p className="whitespace-pre-wrap">{r.content}</p>
               <div className="flex gap-2 text-sm">
-                <button onClick={() => startEdit(r)} className="px-2 py-1 border rounded">Editar</button>
-                <button onClick={() => deleteReview(r.id)} className="px-2 py-1 border rounded">Eliminar</button>
+                <button onClick={() => startEdit(r)} className="px-2 py-1 border border-gray-700 rounded">Editar</button>
+                <button onClick={() => deleteReview(r.id)} className="px-2 py-1 border border-gray-700 rounded">Eliminar</button>
               </div>
             </>
           )}

--- a/Uriel Paul/Tarea10NoSQL/src/components/NavBar.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/components/NavBar.tsx
@@ -30,7 +30,7 @@ export default function NavBar() {
   }, [])
 
   return (
-    <nav className="bg-white border-b">
+    <nav className="bg-gray-800 border-b border-gray-700 text-gray-100">
       <div className="max-w-3xl mx-auto p-4 flex items-center justify-between">
         <div className="flex gap-4">
           <Link href="/">Inicio</Link>
@@ -46,7 +46,7 @@ export default function NavBar() {
                 setToken(null)
                 router.push('/')
               }}
-              className="text-red-600"
+              className="text-red-400"
             >
               Cerrar sesión
             </button>

--- a/Uriel Paul/Tarea10NoSQL/src/components/ReviewForm.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/components/ReviewForm.tsx
@@ -31,16 +31,16 @@ export default function ReviewForm({ bookId, onCreated }: { bookId: string; onCr
   }
 
   return (
-    <div className="space-y-2 p-4 border rounded-xl">
+    <div className="space-y-2 p-4 border border-gray-700 rounded-xl bg-gray-800">
       <div className="font-semibold">Escribir reseña</div>
       <StarRating value={rating} onChange={setRating} />
       <textarea
-        className="w-full border rounded p-2 min-h-24"
+        className="w-full border border-gray-700 rounded p-2 min-h-24 bg-gray-800 text-gray-100"
         placeholder="Contá tu experiencia (mín. 10 caracteres)"
         value={content}
         onChange={e=>setContent(e.target.value)}
       />
-      {error && <div className="text-red-500 text-sm">{error}</div>}
+      {error && <div className="text-red-400 text-sm">{error}</div>}
       <button
         onClick={submit}
         disabled={!canSend || loading}

--- a/Uriel Paul/Tarea10NoSQL/src/components/ReviewList.tsx
+++ b/Uriel Paul/Tarea10NoSQL/src/components/ReviewList.tsx
@@ -123,20 +123,20 @@ export default function ReviewList({
 
   return (
     <div className="space-y-3">
-      {error && <div className="text-red-500 text-sm">{error}</div>}
+      {error && <div className="text-red-400 text-sm">{error}</div>}
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Ordenar:</span>
-        <select value={sort} onChange={e=>setSort(e.target.value as any)} className="border rounded p-1">
+        <span className="text-sm text-gray-400">Ordenar:</span>
+        <select value={sort} onChange={e=>setSort(e.target.value as any)} className="border border-gray-700 rounded p-1 bg-gray-800 text-gray-100">
           <option value="best">Mejores</option>
           <option value="new">Más nuevas</option>
           <option value="rating">Mayor rating</option>
         </select>
       </div>
 
-      {items.length === 0 && <div className="text-gray-500">Sé el primero en reseñar ✍️</div>}
+      {items.length === 0 && <div className="text-gray-400">Sé el primero en reseñar ✍️</div>}
 
       {items.map(r => (
-        <div key={r.id} className="border rounded-xl p-4">
+        <div key={r.id} className="border border-gray-700 rounded-xl p-4 bg-gray-800">
           <div className="flex items-center justify-between">
             <div className="font-medium">{r.userName}</div>
             <div className="text-yellow-500">{'★'.repeat(r.rating)}{'☆'.repeat(5-r.rating)}</div>
@@ -146,28 +146,28 @@ export default function ReviewList({
             <div className="mt-2 space-y-2">
               <StarRating value={editRating} onChange={setEditRating} />
               <textarea
-                className="w-full border rounded p-2"
+                className="w-full border border-gray-700 rounded p-2 bg-gray-800 text-gray-100"
                 value={editContent}
                 onChange={e => setEditContent(e.target.value)}
               />
               <div className="flex gap-2 text-sm">
                 <button onClick={saveEdit} className="px-2 py-1 bg-blue-600 text-white rounded">Guardar</button>
-                <button onClick={() => setEditingId(null)} className="px-2 py-1 border rounded">Cancelar</button>
+                <button onClick={() => setEditingId(null)} className="px-2 py-1 border border-gray-700 rounded">Cancelar</button>
               </div>
             </div>
           ) : (
             <>
               <p className="mt-2 whitespace-pre-wrap">{r.content}</p>
               <div className="mt-3 flex items-center gap-3 text-sm">
-                <button onClick={()=>vote(r.id, 1)} className="px-2 py-1 rounded border">👍 {r.upVotes}</button>
-                <button onClick={()=>vote(r.id, -1)} className="px-2 py-1 rounded border">👎 {r.downVotes}</button>
-                <span className="text-gray-500">Score: {r.score.toFixed(3)}</span>
-                <span className="text-gray-400">{new Date(r.createdAt).toLocaleString()}</span>
+                <button onClick={()=>vote(r.id, 1)} className="px-2 py-1 rounded border border-gray-700 bg-gray-800">👍 {r.upVotes}</button>
+                <button onClick={()=>vote(r.id, -1)} className="px-2 py-1 rounded border border-gray-700 bg-gray-800">👎 {r.downVotes}</button>
+                <span className="text-gray-400">Score: {r.score.toFixed(3)}</span>
+                <span className="text-gray-500">{new Date(r.createdAt).toLocaleString()}</span>
               </div>
               {r.userId === userId && (
                 <div className="mt-2 flex gap-2 text-sm">
-                  <button onClick={() => { setEditingId(r.id); setEditRating(r.rating); setEditContent(r.content) }} className="px-2 py-1 border rounded">Editar</button>
-                  <button onClick={() => deleteReview(r.id)} className="px-2 py-1 border rounded">Eliminar</button>
+                  <button onClick={() => { setEditingId(r.id); setEditRating(r.rating); setEditContent(r.content) }} className="px-2 py-1 border border-gray-700 rounded">Editar</button>
+                  <button onClick={() => deleteReview(r.id)} className="px-2 py-1 border border-gray-700 rounded">Eliminar</button>
                 </div>
               )}
             </>


### PR DESCRIPTION
## Summary
- switch layout and navigation to dark colors
- style inputs, lists and pages for a consistent dark theme
- adjust review components and links to use dark-friendly colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6da28c1c8832bbc777feac42ca6d5